### PR TITLE
improvements to the national-parks plan

### DIFF
--- a/national-parks/hooks/init
+++ b/national-parks/hooks/init
@@ -1,19 +1,21 @@
 #!/bin/bash
 exec 2>&1
+echo "Preparing TOMCAT_HOME..."
+
+# Create a Tomcat root for this app in the package's service directory
+cp -a {{pkgPathFor "core/tomcat8"}}/tc {{pkg.svc_var_path}}/
+
+echo "Done preparing TOMCAT_HOME"
+
 echo "Seeding Mongo Collection"
-MONGODB_HOME=$(hab pkg path learn/mongodb)
 
 {{~#if bind.database}}
-{{~#each bind.database.members}}
-
-  export MONGOIMPORT_OPTS="--host={{sys.ip}} --port={{cfg.port}}"
-
-{{~/each}}
+  export MONGOIMPORT_OPTS="--host={{bind.database.first.sys.ip}} --port={{bind.database.first.cfg.port}}"
 {{~/if}}
 
 echo "\$MONGOIMPORT_OPTS=$MONGOIMPORT_OPTS"
 
-$(hab pkg path core/mongo-tools)/bin/mongoimport --drop -d demo -c nationalparks --type json --jsonArray --file {{pkg.path}}/national-parks.json ${MONGOIMPORT_OPTS}
+{{pkgPathFor "core/mongo-tools"}}/bin/mongoimport --drop -d demo -c nationalparks --type json --jsonArray --file {{pkg.path}}/national-parks.json ${MONGOIMPORT_OPTS}
 
 
 

--- a/national-parks/hooks/run
+++ b/national-parks/hooks/run
@@ -2,20 +2,18 @@
 exec 2>&1
 echo "Starting Apache Tomcat"
 
-export JAVA_HOME=$(hab pkg path core/jdk8)
-export TOMCAT_HOME="$(hab pkg path core/tomcat8)/tc"
+export JAVA_HOME={{pkgPathFor "core/jre8"}}
+export TOMCAT_HOME={{pkg.svc_var_path}}/tc
 
-{{#if bind.has_database}}
-{{~#each bind.database.members as |member|}}
-{{~#if member.alive}}
-  export CATALINA_OPTS="-DMONGODB_SERVICE_HOST={{member.sys.ip}} -DMONGODB_SERVICE_PORT={{member.cfg.port}}
-{{~/if}}
-{{~/each}}
-{{~/if}}
+{{#if bind.database ~}}
+export CATALINA_OPTS="-DMONGODB_SERVICE_HOST={{bind.database.first.sys.ip}} -DMONGODB_SERVICE_PORT={{bind.database.first.cfg.port}}"
+{{else ~}}
+echo "I've got no database bound, yo."
+{{/if ~}}
 
 echo "\$CATALINA_OPTS=$CATALINA_OPTS"
 
-cp "$(hab pkg path {{pkg.origin}}/{{pkg.name}})/{{pkg.name}}.war" "$TOMCAT_HOME/webapps/"
+cp "{{pkg.path}}/{{pkg.name}}.war" "$TOMCAT_HOME/webapps/"
 
 exec ${TOMCAT_HOME}/bin/catalina.sh run
 

--- a/national-parks/plan.sh
+++ b/national-parks/plan.sh
@@ -7,8 +7,8 @@ pkg_license=('Apache-2.0')
 pkg_source=https://github.com/billmeyer/national-parks/archive/v${pkg_version}.tar.gz
 pkg_shasum=7f21dc6e0c8f7f48a2bdbb366f3bfa13e161813282f03ba09a135f8b945e4f16
 pkg_upstream_url=https://github.com/billmeyer/national-parks
-pkg_deps=(core/tomcat8 core/jdk8 core/mongo-tools learn/mongodb)
-pkg_build_deps=(core/maven)
+pkg_deps=(core/jre8/8u131 core/tomcat8 core/mongo-tools)
+pkg_build_deps=(core/jdk8/8u131 core/maven)
 pkg_exports=(
   [port]=port
 )
@@ -24,16 +24,15 @@ pkg_svc_group="root"
 do_build() {
   build_line "do_build() ====================================="
   # Maven requires JAVA_HOME to be set, and can be set via:
-  export JAVA_HOME=$(hab pkg path core/jdk8)
+  export JAVA_HOME=$(pkg_path_for core/jdk8)
   mvn package
 }
+
 do_install() {
   build_line "do_install() ==================================="
-  # The files created during do_build() need to be copied into the
-  # tomcat webapps directory.
-  local webapps_dir="$(hab pkg path core/tomcat8)/tc/webapps"
-  cp target/${pkg_name}.war ${webapps_dir}/
-  # Seed data will be loaded into Mongo using our init hook
+  # The files created during do_build() need to be copied into
+  # our pkg_prefix directory for inclusion in the built package.
   cp target/${pkg_name}.war ${pkg_prefix}
+  # Seed data gets packaged also to be loaded into Mongo using our init hook
   cp national-parks.json ${pkg_prefix}
 }


### PR DESCRIPTION
* replaces occurrences of `$(hab pkg path ..)` with the functions available for using the specific version the package depends on:
    * `$(pkg_path_for ..)` in the plan
    * `{{pkg.path}}` for this package's path
    * `{{pkgPathFor ..}}` in hooks for packages depended upon
* removes the dependency on mongodb - don't need to know the HOME to do the import
* moves jdk8 to being a build dependency, adds jre8 as runtime dep (both with the latest stable version set because there is a bug in version ordering for Java's style)
* uses bind.database.first instead of iterating over all database members
* moves the `TOMCAT_HOME` to `{{pkg.svc_var_path}}` so that this package is not modifying the installed Tomcat package's "immutable" contents
